### PR TITLE
fix for cache showing server working even when its shutdown

### DIFF
--- a/clustercheck.py
+++ b/clustercheck.py
@@ -54,6 +54,7 @@ class clustercheck(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
             if len(res) == 0:
+                opts.last_query_result = 0
                 self.send_response(503)
                 self.send_header("Content-type", "text/html")
                 self.end_headers()


### PR DESCRIPTION
Before this the cache would print last message which was SYNC OK if i stopped the mysql server while running a loop of requests to the clustercheck daemon. 
