### PR TITLE
Exclude benchmark/ directory when creating sdist tarball

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,3 +2,4 @@ David Busby <oneiroi@fedoraproject.org> / <david.busby@percona.com>
 Raghavendra Prabhu <raghavendra.prabhu@percona.com> / <rprabhu@wnohang.net>
 Adrian Lopez <adrianlzt@gmail.com>
 lefred & grypryg from Belcona
+Thomas Bechtold <tbechtold@suse.com>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+prune benchmark
+exclude .gitignore

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='clustercheck',
       use_scm_version=True,
@@ -13,5 +13,5 @@ setup(name='clustercheck',
       author='David Busby',
       author_email='oneiroi@fedoraproject.org',
       url='https://github.com/Oneiroi/clustercheck/',
-      packages=['clustercheck'],
+      packages=find_packages(),
 )


### PR DESCRIPTION
Including the benchmark/ dir results in a ~18 MB sdist tarball. That
doesn't make sense and having the benchmarks installed also doesn't
make sense. So exclude the dir.
Also add myself to the AUTHORS.txt file.