### PR TITLE
Add read timeout to prevent connection hanging forever

### DIFF
--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -31,6 +31,7 @@ class opts:
     being_updated        = False
     # Overriding the connect timeout so that status check doesn't hang
     c_timeout              = 10
+    r_timeout              = 5
 
 class ServerStatus(resource.Resource):
     isLeaf = True
@@ -56,6 +57,7 @@ class ServerStatus(resource.Resource):
             try:
                 conn = pymysql.connect(read_default_file = opts.cnf_file,
                                        connect_timeout = opts.c_timeout,
+                                       read_timeout = opts.r_timeout,
                                        cursorclass = pymysql.cursors.DictCursor)
 
                 if conn:


### PR DESCRIPTION
Sometimes the DB accepts a connection but hangs thereafter which
leaves being_updated stuck at True forever. Then all new requests
are taken from the cache which never gets refreshed and can return
the wrong result which can lead to serious DB problems.