### PR TITLE
Add basic test infrastructure and a first pep8 job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 dist/
 clustercheck.egg-info/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: python
+matrix:
+  include:
+  - python: 3.7
+    env: TOX_ENV=pep8
+  # - python: 2.7
+  #   env: TOX_ENV=py27
+  # - python: 3.7
+  #   env: TOX_ENV=py37
+install:
+- pip install tox
+script:
+- tox -e $TOX_ENV

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This version is rewritten to use Python twisted, so this module is required.
 To start at run time:
 echo "/usr/bin/pyclustercheck -f /etc/my.cnf > /var/log/messages 2>&1 &" >> /etc/rc.local
 
+Running the testsuite
+=====================
+Currently there are only linter tests available. Theses can be executed via `tox`:
+
+    tox -epep8
+
 Contribute
 ==========
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+envlist = py27,py37
+skipsdist = True
+
+[testenv]
+usedevelop = True
+
+[testenv:pep8]
+basepython = python3
+deps = flake8
+commands =
+  flake8 {posargs}
+
+[flake8]
+ignore =
+  F401 # 'argparse' imported but unused
+  E501 # line too long (195 > 79 characters)
+  E221 # multiple spaces before operator
+  E302 # expected 2 blank lines, found 1
+  E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
+  E265 # block comment should start with '# '
+  E261 # at least two spaces before inline comment
+  E262 # inline comment should start with '# '
+  E251 # unexpected spaces around keyword / parameter equals
+  E231 # missing whitespace after ','
+  E999 # SyntaxError: invalid syntax
+  F841 # local variable 'e' is assigned to but never used
+  F821 # undefined name 'MySQLdb'
+  E124 # closing bracket does not match visual indentation
+  E225 # missing whitespace around operator
+  E305 # expected 2 blank lines after class or function definition, found 1
+


### PR DESCRIPTION
Basic test infrastructure is added with tox[1] and TravisCI.
Currently we only have a lint (pep8/flake8) job which ignores all
failures. Follow up commits will fix the failures step by step.
Also the plan is to add basic unit tests and maybe functional tests.

[1] https://tox.readthedocs.io/en/latest/