### PR TITLE
Add clustercheck to console_scripts and fix pep8 style checks

### DIFF
--- a/benchmark/clustercheck/test_scripts/v_user.py
+++ b/benchmark/clustercheck/test_scripts/v_user.py
@@ -2,6 +2,7 @@
 import time
 import mechanize
 
+
 class Transaction(object):
     def __init__(self):
         pass

--- a/benchmark/clustercheck/test_scripts/v_user.py
+++ b/benchmark/clustercheck/test_scripts/v_user.py
@@ -20,4 +20,4 @@ class Transaction(object):
 if __name__ == '__main__':
     trans = Transaction()
     trans.run()
-    print trans.custom_timers
+    print(trans.custom_timers)

--- a/benchmark/clustercheck/test_scripts/v_user.py
+++ b/benchmark/clustercheck/test_scripts/v_user.py
@@ -14,7 +14,7 @@ class Transaction(object):
         resp.read()
         latency = time.time() - start
         self.custom_timers['Cluster_check_latency'] = latency
-        assert (resp.code in (200,503)), 'Bad HTTP Response'
+        assert (resp.code in (200, 503)), 'Bad HTTP Response'
 
 
 if __name__ == '__main__':

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -115,7 +115,8 @@ To test:
 curl http://127.0.0.1:8000
 
 """
-if __name__ == '__main__':
+
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-a','--available-when-donor', dest='awd', default=0, help="Available when donor [default: %(default)s]")
     parser.add_argument('-r','--disable-when-readonly', action='store_true', dest='dwr', default=False, help="Disable when read_only flag is set (desirable wen wanting to take a node out of the cluster wihtout desync) [default: %(default)s]")
@@ -140,3 +141,7 @@ if __name__ == '__main__':
     logger.info('Starting clustercheck...')
     reactor.listenTCP(int(args.port), server.Site(ServerStatus()), interface=bind)
     reactor.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -75,7 +75,7 @@ class ServerStatus(resource.Resource):
                     conn.close() #we're done with the connection let's not hang around
                     opts.being_updated = False #reset the flag
 
-            except pymysql.OperationalError as e:
+            except pymysql.OperationalError as e:  # noqa
                 opts.being_updated = False #corrects bug where the flag is never reset on a communication failiure
                 logger.exception("Can not get wsrep status")
         else:

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import sys
 from twisted.web import server, resource
 from twisted.internet import reactor
 import pymysql

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -46,7 +46,7 @@ class ServerStatus(resource.Resource):
         ttl = opts.last_query_time + opts.cache_time - ctime
         request.setHeader("Server", "PXC Python clustercheck / 2.0")
 
-        if (ttl <= 0) and opts.being_updated == False:
+        if (ttl <= 0) and opts.being_updated is False:
             # cache expired
             opts.being_updated = True  # prevent mutliple threads falling through to MySQL for update
             opts.last_query_time = ctime

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -31,6 +31,7 @@ class opts:
     c_timeout = 10
     r_timeout = 5
 
+
 class ServerStatus(resource.Resource):
     isLeaf = True
 
@@ -114,6 +115,7 @@ To test:
 curl http://127.0.0.1:8000
 
 """
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -108,14 +108,6 @@ class ServerStatus(resource.Resource):
 
         return httpres
 
-"""
-Usage:
-pyclustercheck &>$LOGFILE &
-To test:
-curl http://127.0.0.1:8000
-
-"""
-
 
 def main():
     parser = argparse.ArgumentParser()

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -91,7 +91,7 @@ class ServerStatus(resource.Resource):
             request.setResponseCode(503)
             request.setHeader("Content-type", "text/html")
             httpres = "Percona XtraDB Cluster Node state could not be retrieved."
-            res=()
+            res = ()
             opts.last_query_response = res
             logger.warning('{} (503)'.format(httpres))
         elif res[0]['Value'] == '4' or (int(opts.available_when_donor) == 1 and res[0]['Value'] == '2'):

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -46,10 +46,10 @@ class ServerStatus(resource.Resource):
         request.setHeader("Server", "PXC Python clustercheck / 2.0")
 
         if (ttl <= 0) and opts.being_updated == False:
-            #cache expired
+            # cache expired
             opts.being_updated = True #prevent mutliple threads falling through to MySQL for update
             opts.last_query_time = ctime
-            #add some informational headers
+            # add some informational headers
             request.setHeader("X-Cache", [False, ])
 
             try:
@@ -78,13 +78,13 @@ class ServerStatus(resource.Resource):
                 opts.being_updated = False #corrects bug where the flag is never reset on a communication failiure
                 logger.exception("Can not get wsrep status")
         else:
-            #add some informational headers
+            # add some informational headers
             request.setHeader("X-Cache", True)
             request.setHeader("X-Cache-TTL", "%d" % ttl)
             request.setHeader("X-Cache-Updating", opts.being_updated)
             request.setHeader("X-Cache-disable-when-RO", opts.disable_when_ro)
             request.setHeader("X-Cache-node-is-RO", opts.is_ro)
-            #run from cached response
+            # run from cached response
             res = opts.last_query_response
 
         if len(res) == 0:

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -20,16 +20,16 @@ logger = logging.getLogger(__name__)
 
 class opts:
     available_when_donor = 0
-    disable_when_ro      = 0
-    is_ro                = 0
-    cache_time           = 1
-    last_query_time      = 0
-    last_query_result    = 0
-    cnf_file             = '~/.my.cnf'
-    being_updated        = False
+    disable_when_ro = 0
+    is_ro = 0
+    cache_time = 1
+    last_query_time = 0
+    last_query_result = 0
+    cnf_file = '~/.my.cnf'
+    being_updated = False
     # Overriding the connect timeout so that status check doesn't hang
-    c_timeout              = 10
-    r_timeout              = 5
+    c_timeout = 10
+    r_timeout = 5
 
 class ServerStatus(resource.Resource):
     isLeaf = True
@@ -38,11 +38,11 @@ class ServerStatus(resource.Resource):
         return self.render_GET(request)
 
     def render_GET(self, request):
-        conn    = None
-        res     = ''
+        conn = None
+        res = ''
         httpres = ''
-        ctime   = time.time()
-        ttl     = opts.last_query_time + opts.cache_time - ctime
+        ctime = time.time()
+        ttl = opts.last_query_time + opts.cache_time - ctime
         request.setHeader("Server", "PXC Python clustercheck / 2.0")
 
         if (ttl <= 0) and opts.being_updated == False:
@@ -127,9 +127,9 @@ def main():
 
     args = parser.parse_args()
     opts.available_when_donor = args.awd
-    opts.disable_when_ro      = args.dwr
-    opts.cnf_file             = args.cnf
-    opts.cache_time           = int(args.cache)
+    opts.disable_when_ro = args.dwr
+    opts.cnf_file = args.cnf
+    opts.cache_time = int(args.cache)
 
     bind = "::" if args.ipv6 else args.ipv4
 

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -48,7 +48,7 @@ class ServerStatus(resource.Resource):
 
         if (ttl <= 0) and opts.being_updated == False:
             # cache expired
-            opts.being_updated = True #prevent mutliple threads falling through to MySQL for update
+            opts.being_updated = True  # prevent mutliple threads falling through to MySQL for update
             opts.last_query_time = ctime
             # add some informational headers
             request.setHeader("X-Cache", [False, ])
@@ -69,14 +69,14 @@ class ServerStatus(resource.Resource):
                         curs.execute("SHOW VARIABLES LIKE 'read_only'")
                         ro = curs.fetchone()
                         if ro['Value'].lower() in ('on', '1'):
-                            res = () #read_only is set and opts.disable_when_ro is also set, we should return this node as down
+                            res = ()  # read_only is set and opts.disable_when_ro is also set, we should return this node as down
                             opts.is_ro = True
 
-                    conn.close() #we're done with the connection let's not hang around
-                    opts.being_updated = False #reset the flag
+                    conn.close()  # we're done with the connection let's not hang around
+                    opts.being_updated = False  # reset the flag
 
             except pymysql.OperationalError as e:  # noqa
-                opts.being_updated = False #corrects bug where the flag is never reset on a communication failiure
+                opts.being_updated = False  # corrects bug where the flag is never reset on a communication failiure
                 logger.exception("Can not get wsrep status")
         else:
             # add some informational headers

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -54,10 +54,10 @@ class ServerStatus(resource.Resource):
             request.setHeader("X-Cache", [False, ])
 
             try:
-                conn = pymysql.connect(read_default_file = opts.cnf_file,
-                                       connect_timeout = opts.c_timeout,
-                                       read_timeout = opts.r_timeout,
-                                       cursorclass = pymysql.cursors.DictCursor)
+                conn = pymysql.connect(read_default_file=opts.cnf_file,
+                                       connect_timeout=opts.c_timeout,
+                                       read_timeout=opts.r_timeout,
+                                       cursorclass=pymysql.cursors.DictCursor)
 
                 if conn:
                     curs = conn.cursor()

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -117,13 +117,13 @@ curl http://127.0.0.1:8000
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-a','--available-when-donor', dest='awd', default=0, help="Available when donor [default: %(default)s]")
-    parser.add_argument('-r','--disable-when-readonly', action='store_true', dest='dwr', default=False, help="Disable when read_only flag is set (desirable wen wanting to take a node out of the cluster wihtout desync) [default: %(default)s]")
-    parser.add_argument('-c','--cache-time', dest='cache', default=1, help="Cache the last response for N seconds [default: %(default)s]")
-    parser.add_argument('-f','--conf', dest='cnf', default='~/.my.cnf', help="MySQL Config file to use [default: %(default)s]")
-    parser.add_argument('-p','--port', dest='port', default=8000, help="Port to listen on [default: %(default)s]")
-    parser.add_argument('-6','--ipv6', dest='ipv6', action='store_true', default=False, help="Listen to ipv6 only (disabled ipv4) [default: %(default)s]")
-    parser.add_argument('-4','--ipv4', dest='ipv4', default='0.0.0.0', help="Listen to ipv4 on this address [default: %(default)s]")
+    parser.add_argument('-a', '--available-when-donor', dest='awd', default=0, help="Available when donor [default: %(default)s]")
+    parser.add_argument('-r', '--disable-when-readonly', action='store_true', dest='dwr', default=False, help="Disable when read_only flag is set (desirable wen wanting to take a node out of the cluster wihtout desync) [default: %(default)s]")
+    parser.add_argument('-c', '--cache-time', dest='cache', default=1, help="Cache the last response for N seconds [default: %(default)s]")
+    parser.add_argument('-f', '--conf', dest='cnf', default='~/.my.cnf', help="MySQL Config file to use [default: %(default)s]")
+    parser.add_argument('-p', '--port', dest='port', default=8000, help="Port to listen on [default: %(default)s]")
+    parser.add_argument('-6', '--ipv6', dest='ipv6', action='store_true', default=False, help="Listen to ipv6 only (disabled ipv4) [default: %(default)s]")
+    parser.add_argument('-4', '--ipv4', dest='ipv4', default='0.0.0.0', help="Listen to ipv4 on this address [default: %(default)s]")
 
     args = parser.parse_args()
     opts.available_when_donor = args.awd

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,9 @@ setup(name='clustercheck',
       author_email='oneiroi@fedoraproject.org',
       url='https://github.com/Oneiroi/clustercheck/',
       packages=find_packages(),
+      entry_points={
+          'console_scripts': [
+              'clustercheck = clustercheck:main',
+          ],
+      }
 )

--- a/setup.py
+++ b/setup.py
@@ -3,23 +3,24 @@
 
 from setuptools import setup, find_packages
 
-setup(name='clustercheck',
-      use_scm_version=True,
-      setup_requires=['setuptools_scm'],
-      install_requires=[
-          'Twisted>=12.2',
-          'PyMySQL'
-      ],
-      description='Standalone service for reporting of Percona XtraDB/Galera cluster nodes',
-      license='AGPL-3.0-only',
-      keywords='galera,mariadb,percona,database,cluster',
-      author='David Busby',
-      author_email='oneiroi@fedoraproject.org',
-      url='https://github.com/Oneiroi/clustercheck/',
-      packages=find_packages(),
-      entry_points={
-          'console_scripts': [
-              'clustercheck = clustercheck:main',
-          ],
-      }
+setup(
+    name='clustercheck',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
+    install_requires=[
+        'Twisted>=12.2',
+        'PyMySQL'
+    ],
+    description='Standalone service for reporting of Percona XtraDB/Galera cluster nodes',
+    license='AGPL-3.0-only',
+    keywords='galera,mariadb,percona,database,cluster',
+    author='David Busby',
+    author_email='oneiroi@fedoraproject.org',
+    url='https://github.com/Oneiroi/clustercheck/',
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'clustercheck = clustercheck:main',
+        ],
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
 ignore =
   E501 # line too long (195 > 79 characters)
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
-  E251 # unexpected spaces around keyword / parameter equals
   E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ ignore =
   E501 # line too long (195 > 79 characters)
   E302 # expected 2 blank lines, found 1
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
-  E265 # block comment should start with '# '
   E261 # at least two spaces before inline comment
   E262 # inline comment should start with '# '
   E251 # unexpected spaces around keyword / parameter equals

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,4 @@ commands =
 [flake8]
 ignore =
   E501 # line too long (195 > 79 characters)
-  E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,5 @@ ignore =
   F841 # local variable 'e' is assigned to but never used
   F821 # undefined name 'MySQLdb'
   E124 # closing bracket does not match visual indentation
-  E225 # missing whitespace around operator
   E305 # expected 2 blank lines after class or function definition, found 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands =
 [flake8]
 ignore =
   E501 # line too long (195 > 79 characters)
-  E221 # multiple spaces before operator
   E302 # expected 2 blank lines, found 1
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
   E265 # block comment should start with '# '

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ ignore =
   E231 # missing whitespace after ','
   E999 # SyntaxError: invalid syntax
   F841 # local variable 'e' is assigned to but never used
-  F821 # undefined name 'MySQLdb'
   E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
 ignore =
   E501 # line too long (195 > 79 characters)
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
-  E261 # at least two spaces before inline comment
   E262 # inline comment should start with '# '
   E251 # unexpected spaces around keyword / parameter equals
   E124 # closing bracket does not match visual indentation

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
 ignore =
   E501 # line too long (195 > 79 characters)
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
-  E262 # inline comment should start with '# '
   E251 # unexpected spaces around keyword / parameter equals
   E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ ignore =
   E261 # at least two spaces before inline comment
   E262 # inline comment should start with '# '
   E251 # unexpected spaces around keyword / parameter equals
-  E231 # missing whitespace after ','
   F841 # local variable 'e' is assigned to but never used
   E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ ignore =
   E262 # inline comment should start with '# '
   E251 # unexpected spaces around keyword / parameter equals
   E231 # missing whitespace after ','
-  E999 # SyntaxError: invalid syntax
   F841 # local variable 'e' is assigned to but never used
   E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ ignore =
   E261 # at least two spaces before inline comment
   E262 # inline comment should start with '# '
   E251 # unexpected spaces around keyword / parameter equals
-  F841 # local variable 'e' is assigned to but never used
   E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands =
 [flake8]
 ignore =
   E501 # line too long (195 > 79 characters)
-  E302 # expected 2 blank lines, found 1
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
   E261 # at least two spaces before inline comment
   E262 # inline comment should start with '# '

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,5 @@ commands =
 ignore =
   E501 # line too long (195 > 79 characters)
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
-  E124 # closing bracket does not match visual indentation
   E305 # expected 2 blank lines after class or function definition, found 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ commands =
 
 [flake8]
 ignore =
-  F401 # 'argparse' imported but unused
   E501 # line too long (195 > 79 characters)
   E221 # multiple spaces before operator
   E302 # expected 2 blank lines, found 1

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,4 @@ commands =
 ignore =
   E501 # line too long (195 > 79 characters)
   E712 # comparison to False should be 'if cond is False:' or 'if not cond:'
-  E305 # expected 2 blank lines after class or function definition, found 1
 


### PR DESCRIPTION
When installing clustercheck via pip, the clustercheck executable
should be installed into the bin path. Use the entry_points
console_scripts mechanism for that.