### PR TITLE
Use strings when setting X-Cache header

### DIFF
--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -2,7 +2,6 @@
 
 import argparse
 from contextlib import contextmanager
-from importlib import import_module
 import os
 from twisted.web import server, resource
 from twisted.internet import reactor, task
@@ -184,7 +183,7 @@ def main():
     watchdog_usec = os.getenv('WATCHDOG_USEC')
     if watchdog_usec:
         logger.info('systemd watchdog support enabled')
-        watchdog_sec = int(watchdog_usec)/1000000/2.0
+        watchdog_sec = int(watchdog_usec) / 1000000 / 2.0
         watchdog_call = task.LoopingCall(_systemd_watchdog_ping, notifier)
         watchdog_call.start(watchdog_sec)
         logger.info('systemd watchdog looping call every {} s'.format(

--- a/clustercheck/__init__.py
+++ b/clustercheck/__init__.py
@@ -80,9 +80,9 @@ def _prepare_request_response_headers(request, cache_ttl):
     # cache information
     request.setHeader("X-Cache-TTL", "%d" % cache_ttl)
     if cache_ttl <= 0:
-        request.setHeader("X-Cache", False)
+        request.setHeader("X-Cache", "%s" % False)
     else:
-        request.setHeader("X-Cache", True)
+        request.setHeader("X-Cache", "%s" % True)
 
 
 def _systemd_watchdog_ping(notifier):


### PR DESCRIPTION
Using a bool value does not work and will result in:

  exceptions.AttributeError: 'bool' object has no attribute 'splitlines'

Also fix pep8